### PR TITLE
Feature: Custom CSS cursors for box rotation and scaling in Transformer

### DIFF
--- a/packages/react-bindings/src/Transformer.ts
+++ b/packages/react-bindings/src/Transformer.ts
@@ -4,7 +4,7 @@ import { PixiComponent, applyDefaultProps } from '@inlet/react-pixi';
 import { Transformer as TransformerImpl, TransformerHandle as TransformerHandleImpl } from '@pixi-essentials/transformer';
 import { applyEventProps } from './utils/applyEventProps';
 
-import type { ITransformerStyle, ITransformerHandleStyle } from '@pixi-essentials/transformer';
+import type { ITransformerCursors, ITransformerStyle, ITransformerHandleStyle } from '@pixi-essentials/transformer';
 import type React from 'react';
 
 const EMPTY: any = {};
@@ -19,6 +19,7 @@ export type TransformerProps = {
     boxRotationEnabled?: boolean;
     boxRotationTolerance?: number;
     centeredScaling?: boolean;
+    cursors?: Partial<ITransformerCursors>;
     enabledHandles?: Array<string>;
     group?: DisplayObject[];
     handleConstructor?: typeof TransformerHandleImpl;
@@ -55,6 +56,11 @@ export const Transformer: React.FC<TransformerProps> = PixiComponent<Transformer
     {
         applyDefaultProps(instance, oldProps, newProps);
         applyEventProps(instance, HANDLER_TO_EVENT, oldProps, newProps);
+
+        if (newProps.cursors)
+        {
+            Object.assign(instance.cursors, newProps.cursors);
+        }
 
         instance.group = newProps.group || [];
 

--- a/packages/transformer/src/TransformerHandle.ts
+++ b/packages/transformer/src/TransformerHandle.ts
@@ -5,34 +5,22 @@ import { Renderer } from '@pixi/core';
 import { InteractionEvent } from '@pixi/interaction';
 import type { Handle } from './Transformer';
 
-/**
- * @see TransformerHandle#style
- */
+/** @see TransformerHandle#style */
 export interface ITransformerHandleStyle
 {
-    /**
-     * Fill color of the handle
-     */
+    /** Fill color of the handle */
     color: number;
 
-    /**
-     * Outline color of the handle
-     */
+    /** Outline color of the handle */
     outlineColor: number;
 
-    /**
-     * Outline thickness around the handle
-     */
+    /** Outline thickness around the handle */
     outlineThickness: number;
 
-    /**
-     * Radius (or size for non-circular handles) of the handle
-     */
+    /** Radius (or size for non-circular handles) of the handle */
     radius: number;
 
-    /**
-     * {@link TransformerHandle} provides three types of handle shapes - 'circle', 'square', 'tooth'.
-     */
+    /** {@link TransformerHandle} provides three types of handle shapes - 'circle', 'square', 'tooth'. */
     shape: string;
 }
 

--- a/packages/transformer/src/index.ts
+++ b/packages/transformer/src/index.ts
@@ -11,6 +11,7 @@ export type {
     ScaleHandle,
     SkewHandle,
     ITransformerOptions,
-    ITransformerStyle
+    ITransformerStyle,
+    ITransformerCursors,
 } from './Transformer';
 export type { ITransformerHandleStyle } from './TransformerHandle';


### PR DESCRIPTION
Also, remove options documentation in Transformer's constructor - since the options interfaces can document that.