### PR TITLE
SVG Scene - avoid memory leaks: recursively destroy root container too

### DIFF
--- a/packages/svg/src/SVGScene.ts
+++ b/packages/svg/src/SVGScene.ts
@@ -153,6 +153,15 @@ export class SVGScene extends DisplayObject
     /**
      * @override
      */
+    destroy(): void {
+        this.root.destroy(true);
+
+        super.destroy();
+    }
+
+    /**
+     * @override
+     */
     render(renderer: Renderer): void
     {
         if (!this.visible || !this.renderable)


### PR DESCRIPTION
I discovered that the SVGScene is a simple DisplayObject and all the SVGGraphicsGeometry Instances are not removed from the GraphicsSystem when I dynamically want to destroy/create SVGScenes.

so recursively destroying the root container too, fixes the issue.