### PR TITLE
cleaning up temporary sprites and textures in GradientFactory

### DIFF
--- a/packages/gradients/src/GradientFactory.ts
+++ b/packages/gradients/src/GradientFactory.ts
@@ -98,6 +98,9 @@ export class GradientFactory
         renderer.batch.flush();
         renderer.renderTexture.bind(renderTarget, sourceFrame, destinationFrame);
 
+        // Clean up temporary sprite and texture
+        renderSprite.destroy({texture: true, baseTexture: true})
+
         return renderTexture;
     }
 
@@ -166,6 +169,9 @@ export class GradientFactory
         
         renderer.batch.flush();
         renderer.renderTexture.bind(renderTarget, sourceFrame, destinationFrame);
+
+        // Clean up temporary sprite and texture
+        renderSprite.destroy({texture: true, baseTexture: true})
 
         return renderTexture;
     }


### PR DESCRIPTION
I experienced a memory leak due to the temporary sprite not getting destroyed before handing back the `renderTexture`, I don't believe there is any reason to keep this around? So I just destroyed it, its `Texture` and its `BaseTexture`, before handing back the `renderTexture`, which fixed my memory leak.

Edit: Oh and my editor added a newline at the end of the file, hope that's cool.