### PR TITLE
fix(transformer): pointer move issue

### DIFF
--- a/packages/transformer/src/Transformer.ts
+++ b/packages/transformer/src/Transformer.ts
@@ -1313,12 +1313,12 @@ export class Transformer extends Container_
 
         if (this._pointerMoveTarget)
         {
-            this._pointerMoveTarget.removeEventListener('pointermove', this.onPointerMove);
+            this._pointerMoveTarget.removeEventListener('globalpointermove', this.onPointerMove);
             this._pointerMoveTarget = null;
         }
 
         this._pointerMoveTarget = (this.stage || this) as unknown as DisplayObject & IFederatedDisplayObject;
-        this._pointerMoveTarget.addEventListener('pointermove', this.onPointerMove);
+        this._pointerMoveTarget.addEventListener('globalpointermove', this.onPointerMove);
     }
 
     /** Called on the `pointermove` event. You must call the super implementation. */
@@ -1411,7 +1411,7 @@ export class Transformer extends Container_
 
         if (this._pointerMoveTarget)
         {
-            this._pointerMoveTarget.removeEventListener('pointermove', this.onPointerMove);
+            this._pointerMoveTarget.removeEventListener('globalpointermove', this.onPointerMove);
             this._pointerMoveTarget = null;
         }
     }

--- a/packages/transformer/src/TransformerHandle.ts
+++ b/packages/transformer/src/TransformerHandle.ts
@@ -229,12 +229,12 @@ export class TransformerHandle extends Graphics_
 
         if (this._pointerMoveTarget)
         {
-            this._pointerMoveTarget.removeEventListener('pointermove', this.onPointerMove);
+            this._pointerMoveTarget.removeEventListener('globalpointermove', this.onPointerMove);
             this._pointerMoveTarget = null;
         }
 
         this._pointerMoveTarget = (this.transformer.stage || this) as unknown as Container & IFederatedDisplayObject;
-        this._pointerMoveTarget.addEventListener('pointermove', this.onPointerMove);
+        this._pointerMoveTarget.addEventListener('globalpointermove', this.onPointerMove);
     }
 
     /**
@@ -277,7 +277,7 @@ export class TransformerHandle extends Graphics_
 
         if (this._pointerMoveTarget)
         {
-            this._pointerMoveTarget.removeEventListener('pointermove', this.onPointerMove);
+            this._pointerMoveTarget.removeEventListener('globalpointermove', this.onPointerMove);
             this._pointerMoveTarget = null;
         }
     }


### PR DESCRIPTION
fix #73

1. Replace `pointermove` with `globalpointermove` in the first commit
2. ~In the second commit, I added pixi.js@7.2.0 into the transformer's `package.json` and updated the rush config, mind me if it is unnecessary.~

reference: https://github.com/pixijs/pixijs/releases/tag/v7.2.0