### PR TITLE
Support WebGL1 context

### DIFF
--- a/packages/texture-allocator/src/AtlasResource.ts
+++ b/packages/texture-allocator/src/AtlasResource.ts
@@ -156,7 +156,6 @@ export class AtlasResource extends Resource
                 const ctx = source.getContext('2d');
                 const [w, h] = [source.width, source.height];
                 source = ctx.getImageData(0, 0, w, h).data;
-
             } else if (source instanceof HTMLImageElement) {
                 const [w, h] = [source.naturalWidth, source.naturalHeight];
                 const canvas = document.createElement('canvas');

--- a/packages/texture-allocator/src/AtlasResource.ts
+++ b/packages/texture-allocator/src/AtlasResource.ts
@@ -152,7 +152,6 @@ export class AtlasResource extends Resource
         if (!isWebGL2) {
             if (source instanceof ImageData) {
                 source = source.data;  // pass the typed array directly
-
             } else if (source instanceof HTMLCanvasElement) {
                 const ctx = source.getContext('2d');
                 const [w, h] = [source.width, source.height];

--- a/packages/texture-allocator/src/AtlasResource.ts
+++ b/packages/texture-allocator/src/AtlasResource.ts
@@ -144,8 +144,31 @@ export class AtlasResource extends Resource
         }
 
         const gl: WebGLRenderingContext = renderer.gl;
-        const source = item.source;
+        const isWebGL2 = (gl instanceof WebGL2RenderingContext);
         const frame = item.frame;
+        let source = item.source;
+
+        // if WebGL1, convert whatever we have into a typed array
+        if (!isWebGL2) {
+            if (source instanceof ImageData) {
+                source = source.data;  // pass the typed array directly
+
+            } else if (source instanceof HTMLCanvasElement) {
+                const ctx = source.getContext('2d');
+                const [w, h] = [source.width, source.height];
+                source = ctx.getImageData(0, 0, w, h).data;
+
+            } else if (source instanceof HTMLImageElement) {
+                const [w, h] = [source.naturalWidth, source.naturalHeight];
+                const canvas = document.createElement('canvas');
+                canvas.width = w;
+                canvas.height = h;
+
+                const ctx = canvas.getContext('2d');
+                ctx.drawImage(source, 0, 0);
+                source = ctx.getImageData(0, 0, w, h).data;
+            }
+        }
 
         gl.texSubImage2D(
             target,


### PR DESCRIPTION
Thanks for this library!
We found that some of the sources we were adding to the texture atlas weren't compatible with WebGL1 context, needed to support some of our users on older hardware.

This code converts incompatible sources (ImageData, HTMLCanvasElement, HTMLImageElement) to an ArrayBufferView that will work in WebGL1

see https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/texSubImage2D

re https://github.com/rapideditor/pixi-texture-allocator/issues/1